### PR TITLE
Fix GDScript type inference errors

### DIFF
--- a/godot_project/addons/pixel_rope/scripts/components/rope_anchor.gd
+++ b/godot_project/addons/pixel_rope/scripts/components/rope_anchor.gd
@@ -92,7 +92,7 @@ func _input(event: InputEvent) -> void:
 		return
 
 	if event is InputEventMouseButton and event.button_index == MOUSE_BUTTON_LEFT:
-		var mouse := get_viewport().get_canvas_transform().affine_inverse() * event.position
+		var mouse: Vector2 = get_viewport().get_canvas_transform().affine_inverse() * event.position
 
 		if event.pressed:
 			if mouse.distance_to(global_position) <= radius:
@@ -105,7 +105,7 @@ func _input(event: InputEvent) -> void:
 			get_viewport().set_input_as_handled()
 
 	elif event is InputEventMouseMotion and _dragging:
-		var mouse := get_viewport().get_canvas_transform().affine_inverse() * event.position
+		var mouse: Vector2 = get_viewport().get_canvas_transform().affine_inverse() * event.position
 		global_position = mouse + _drag_offset
 		_last_position = position
 		_notify_parent()

--- a/godot_project/addons/pixel_rope/scripts/editor_tools/rope_creation_button.gd
+++ b/godot_project/addons/pixel_rope/scripts/editor_tools/rope_creation_button.gd
@@ -100,5 +100,5 @@ func handle_input(event: InputEvent) -> bool:
 
 
 func _get_world_position(event: InputEvent) -> Vector2:
-	var canvas := plugin_root.get_editor_interface().get_editor_viewport()
+	var canvas: Control = plugin_root.get_editor_interface().get_editor_viewport()
 	return canvas.get_canvas_transform().affine_inverse() * event.position

--- a/godot_project/addons/pixel_rope/scripts/utilities/line_algorithms.gd
+++ b/godot_project/addons/pixel_rope/scripts/utilities/line_algorithms.gd
@@ -42,10 +42,10 @@ static func _bresenham_line(from: Vector2, to: Vector2, pixel_size: int, spacing
 	var y1 := int(to.y / pixel_size)
 
 	var dx := abs(x1 - x0)
-	var dy := -abs(y1 - y0)
+	var dy: int = -abs(y1 - y0)
 	var sx := 1 if x0 < x1 else -1
 	var sy := 1 if y0 < y1 else -1
-	var err := dx + dy
+	var err: int = dx + dy
 	var pixel_count := 0
 
 	while true:
@@ -57,7 +57,7 @@ static func _bresenham_line(from: Vector2, to: Vector2, pixel_size: int, spacing
 		if x0 == x1 and y0 == y1:
 			break
 
-		var e2 := 2 * err
+		var e2: int = 2 * err
 		if e2 >= dy:
 			if x0 == x1: break
 			err += dy
@@ -87,8 +87,8 @@ static func _dda_line(from: Vector2, to: Vector2, pixel_size: int, spacing: int 
 		points.append(Vector2(round(x0) * pixel_size, round(y0) * pixel_size))
 		return points
 
-	var x_inc := dx / steps
-	var y_inc := dy / steps
+	var x_inc: float = dx / steps
+	var y_inc: float = dy / steps
 	var x := x0
 	var y := y0
 


### PR DESCRIPTION
## Summary
- Add explicit type annotations to fix "Cannot infer the type" parse errors in `line_algorithms.gd`, `rope_anchor.gd`, and `rope_creation_button.gd`
- Replaces `:=` with explicit types (`int`, `float`, `Vector2`, `Control`) where GDScript's type inference fails on `abs()`, arithmetic, transform multiplication, and editor API return values
- Fixes 7 parse errors and 2 downstream compile errors that prevented the plugin from loading

## Test plan
- [ ] Open the project in Godot 4.5 and verify no parse/compile errors appear in the output log
- [ ] Confirm the pixel rope plugin loads and renders correctly in the editor
- [ ] Test rope anchor dragging in the editor to verify mouse position calculations work

https://claude.ai/code/session_01AeL8G3tv5t9o1vKU5AbpVB