### PR TITLE
Add physics substeps to rope simulation for improved stability

### DIFF
--- a/godot_project/addons/pixel_rope/scripts/components/rope_node.gd
+++ b/godot_project/addons/pixel_rope/scripts/components/rope_node.gd
@@ -58,6 +58,7 @@ enum GrabMode { NONE, ANCHORS_ONLY, ANY_POINT }
 @export var gravity: Vector2 = Vector2(0, 980)
 @export_range(0.0, 1.0) var damping: float = 0.98
 @export_range(1, 50) var iterations: int = 10
+@export_range(1, 10) var physics_substeps: int = 3
 @export var max_stretch_factor: float = 2.0
 
 # --- Anchors ---
@@ -291,17 +292,20 @@ func _physics_process(delta: float) -> void:
 		queue_redraw()
 		return
 
-	# Pin non-dynamic anchors to their node positions
-	if not dynamic_start_anchor:
-		_points[0] = _start_anchor.global_position
-	if not dynamic_end_anchor:
-		_points[segment_count] = _end_anchor.global_position
+	var sub_delta := delta / float(physics_substeps)
 
-	_verlet_integrate(delta)
-	_solve_constraints()
+	for _substep in physics_substeps:
+		# Pin non-dynamic anchors to their node positions
+		if not dynamic_start_anchor:
+			_points[0] = _start_anchor.global_position
+		if not dynamic_end_anchor:
+			_points[segment_count] = _end_anchor.global_position
 
-	if enable_collisions:
-		_resolve_collisions()
+		_verlet_integrate(sub_delta)
+		_solve_constraints()
+
+		if enable_collisions:
+			_resolve_collisions()
 
 	# Sync dynamic anchor nodes to simulation
 	if dynamic_start_anchor:


### PR DESCRIPTION
## Summary
This change introduces a configurable physics substep system to the rope simulation, allowing the constraint solving and collision resolution to run multiple times per frame for improved stability and accuracy.

## Key Changes
- Added `physics_substeps` export variable (range 1-10, default 3) to control the number of simulation substeps per frame
- Refactored `_physics_process` to subdivide the delta time and run the core simulation loop (integration, constraint solving, and collision resolution) multiple times per substep
- Anchor pinning now occurs at the beginning of each substep to ensure consistent positioning throughout the simulation

## Implementation Details
- The delta time is divided by the number of substeps (`sub_delta := delta / float(physics_substeps)`) to maintain consistent simulation speed
- The verlet integration, constraint solving, and collision resolution now execute within a loop that runs `physics_substeps` times per frame
- This approach allows for better convergence of constraints and more stable collision handling without requiring changes to the core simulation algorithms
- The feature is configurable, allowing users to balance between simulation quality and performance

https://claude.ai/code/session_013Lp7mU4NEqng9jWzNC1TVh